### PR TITLE
Remove stepper bar from adaptive definition

### DIFF
--- a/projects/training-agenda/adaptive-definition-edit/src/components/adaptive-definition/adaptive-training-definition-edit.component.html
+++ b/projects/training-agenda/adaptive-definition-edit/src/components/adaptive-definition/adaptive-training-definition-edit.component.html
@@ -29,18 +29,6 @@
                     </button>
                 </mat-form-field>
 
-                <!-- SHOW STEPPER BAR checkbox-->
-                <div>
-                    <div class="form-line-content">
-                        <mat-checkbox matTooltip="When active, trainee can see which level
-              he is playing and how many there are until the end"
-                                      labelPosition="after"
-                                      formControlName="showProgress">
-                            Show Stepper Bar
-                        </mat-checkbox>
-                    </div>
-                </div>
-
                 <!-- DEFAULT CONTENT checkbox-->
                 <div *ngIf="!trainingDefinition.id">
                     <div class="form-line-content">

--- a/projects/training-agenda/adaptive-definition-edit/src/components/adaptive-definition/adaptive-training-definition-edit.component.ts
+++ b/projects/training-agenda/adaptive-definition-edit/src/components/adaptive-definition/adaptive-training-definition-edit.component.ts
@@ -29,10 +29,6 @@ export class AdaptiveTrainingDefinitionEditComponent implements OnChanges {
         return this.trainingDefinitionEditFormGroup.formGroup.get('description');
     }
 
-    get showProgress(): AbstractControl {
-        return this.trainingDefinitionEditFormGroup.formGroup.get('showProgress');
-    }
-
     get outcomes(): UntypedFormArray {
         return this.trainingDefinitionEditFormGroup.formGroup.get('outcomes') as UntypedFormArray;
     }

--- a/projects/training-agenda/package.json
+++ b/projects/training-agenda/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/training-agenda",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "license": "MIT",
     "peerDependencies": {
         "@angular/common": "^18.2.13",


### PR DESCRIPTION
This checkbox is a leftover code
Stepper bar is now set in a training instance

![image](https://github.com/user-attachments/assets/eeaa2d43-ef69-4e42-9b34-452d339da50e)
