### PR TITLE
Fix topology resize shrinking bug

### DIFF
--- a/projects/training-agenda/adaptive-run-detail/src/components/phase/sandbox-interaction-phase/generic-sandbox-phase/generic-sandbox-phase.component.html
+++ b/projects/training-agenda/adaptive-run-detail/src/components/phase/sandbox-interaction-phase/generic-sandbox-phase/generic-sandbox-phase.component.html
@@ -9,7 +9,7 @@
                 [leftPanelContent]="leftPanelContent"
                 [rightPanelContent]="rightPanelContent"
                 [leftPanelMinWidth]="'20%'"
-                [rightPanelMinWidth]="'510px'"
+                [rightPanelMinWidth]="'20%'"
                 [defaultRatio]="0.6"
                 [dividerPositionSynchronizer]="dividerPositionSynchronizer"
             />

--- a/projects/training-agenda/package.json
+++ b/projects/training-agenda/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/training-agenda",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "license": "MIT",
     "peerDependencies": {
         "@angular/common": "^18.2.13",

--- a/projects/training-agenda/run-detail/src/components/level/sandbox-interaction-level/generic-sandbox-level/generic-sandbox-level.component.html
+++ b/projects/training-agenda/run-detail/src/components/level/sandbox-interaction-level/generic-sandbox-level/generic-sandbox-level.component.html
@@ -8,7 +8,7 @@
                 [leftPanelContent]="leftPanelContent"
                 [rightPanelContent]="rightPanelContent"
                 [leftPanelMinWidth]="'20%'"
-                [rightPanelMinWidth]="'510px'"
+                [rightPanelMinWidth]="'20%'"
                 [defaultRatio]="0.6"
                 [dividerPositionSynchronizer]="dividerPositionSynchronizer"
             />


### PR DESCRIPTION
#15 

The sizes are bugged only in 4k because the bug happens when the min size of the right split panel is in px and the left side panel is in % and the total screen width*percent size > px size.

With the topology being set to 510px min size and level content to 20% min size, only at 4k resolution, the 20% size is larger than 510px. 

This bug is caused by CSS not knowing how to evaluate different units. I fixed it by setting the minimum topology size to % as well.