### PR TITLE
Mitre error deffering

### DIFF
--- a/projects/training-agenda/adaptive-definition-edit/src/components/phases/phase/training-phase/mitre-technique/mitre-technique-select.component.html
+++ b/projects/training-agenda/adaptive-definition-edit/src/components/phases/phase/training-phase/mitre-technique/mitre-technique-select.component.html
@@ -1,4 +1,4 @@
-<mat-expansion-panel>
+<mat-expansion-panel  (click)="emitDeferredErrors()">
     <mat-expansion-panel-header>
         <mat-panel-title> MITRE ATT&CK Techniques</mat-panel-title>
         <mat-panel-description>

--- a/projects/training-agenda/adaptive-definition-edit/src/components/phases/phase/training-phase/mitre-technique/mitre-technique-select.component.ts
+++ b/projects/training-agenda/adaptive-definition-edit/src/components/phases/phase/training-phase/mitre-technique/mitre-technique-select.component.ts
@@ -4,6 +4,7 @@ import { COMMA, ENTER, SEMICOLON } from '@angular/cdk/keycodes';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { UntypedFormControl } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MitreTechniquesService } from '../../../../../services/state/mitre-techniques/mitre-techniques.service';
 
 @Component({
     selector: 'crczp-mitre-technique-select',
@@ -17,6 +18,8 @@ export class MitreTechniqueSelectComponent implements OnChanges {
     @Output() mitreTechniquesChange: EventEmitter<MitreTechnique[]> = new EventEmitter();
 
     @ViewChild('techniqueInput') techniqueInput: ElementRef<HTMLInputElement>;
+
+    constructor(private mitreTechniquesService: MitreTechniquesService) {}
 
     chipListCtrl = new UntypedFormControl();
     filteredTechniquesList: MitreTechnique[];
@@ -93,5 +96,9 @@ export class MitreTechniqueSelectComponent implements OnChanges {
             const techniqueString = `${technique.techniqueKey} - ${technique.techniqueName}`;
             return techniqueString.toLowerCase().includes(filterValue);
         });
+    }
+
+    emitDeferredErrors() {
+        this.mitreTechniquesService.emitDeferredErrors();
     }
 }

--- a/projects/training-agenda/adaptive-definition-edit/src/services/state/mitre-techniques/mitre-techniques-concrete.service.ts
+++ b/projects/training-agenda/adaptive-definition-edit/src/services/state/mitre-techniques/mitre-techniques-concrete.service.ts
@@ -15,12 +15,19 @@ export class MitreTechniquesConcreteService extends MitreTechniquesService {
         super();
     }
 
+    private deferredErrors = [];
+
     getAll(): Observable<MitreTechnique[]> {
         return this.api.getMitreTechniquesList().pipe(
             tap(
                 (res) => this.mitreTechniquesSubject$.next(res),
-                (err) => this.errorHandler.emit(err, 'Loading MITRE techniques list'),
+                (err) => this.deferredErrors.push(err),
             ),
         );
+    }
+
+    emitDeferredErrors(): void {
+        this.deferredErrors.forEach((err) => this.errorHandler.emit(err, 'Loading MITRE techniques list'));
+        this.deferredErrors = [];
     }
 }

--- a/projects/training-agenda/adaptive-definition-edit/src/services/state/mitre-techniques/mitre-techniques.service.ts
+++ b/projects/training-agenda/adaptive-definition-edit/src/services/state/mitre-techniques/mitre-techniques.service.ts
@@ -11,4 +11,6 @@ export abstract class MitreTechniquesService {
     mitreTechniques$ = this.mitreTechniquesSubject$.asObservable();
 
     abstract getAll(): Observable<any>;
+
+    abstract emitDeferredErrors(): void;
 }

--- a/projects/training-agenda/definition-edit/src/components/levels/level/training/mitre-technique/mitre-technique-select.component.html
+++ b/projects/training-agenda/definition-edit/src/components/levels/level/training/mitre-technique/mitre-technique-select.component.html
@@ -1,4 +1,4 @@
-<mat-expansion-panel>
+<mat-expansion-panel (click)="emitDeferredErrors()">
     <mat-expansion-panel-header>
         <mat-panel-title> MITRE ATT&CK Techniques</mat-panel-title>
         <mat-panel-description>

--- a/projects/training-agenda/definition-edit/src/components/levels/level/training/mitre-technique/mitre-technique-select.component.ts
+++ b/projects/training-agenda/definition-edit/src/components/levels/level/training/mitre-technique/mitre-technique-select.component.ts
@@ -4,6 +4,7 @@ import { COMMA, ENTER, SEMICOLON } from '@angular/cdk/keycodes';
 import { MatChipInputEvent } from '@angular/material/chips';
 import { UntypedFormControl } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MitreTechniquesService } from '../../../../../services/state/mitre-techniques/mitre-techniques.service';
 
 @Component({
     selector: 'crczp-mitre-technique-select',
@@ -17,6 +18,8 @@ export class MitreTechniqueSelectComponent implements OnChanges {
     @Output() mitreTechniquesChange: EventEmitter<MitreTechnique[]> = new EventEmitter();
 
     @ViewChild('techniqueInput') techniqueInput: ElementRef<HTMLInputElement>;
+
+    constructor(private mitreTechniquesService: MitreTechniquesService) {}
 
     chipListCtrl = new UntypedFormControl();
     filteredTechniquesList: MitreTechnique[];
@@ -93,5 +96,9 @@ export class MitreTechniqueSelectComponent implements OnChanges {
             const techniqueString = `${technique.techniqueKey} - ${technique.techniqueName}`;
             return techniqueString.toLowerCase().includes(filterValue);
         });
+    }
+
+    emitDeferredErrors() {
+        this.mitreTechniquesService.emitDeferredErrors();
     }
 }

--- a/projects/training-agenda/definition-edit/src/services/state/mitre-techniques/mitre-techniques-concrete.service.ts
+++ b/projects/training-agenda/definition-edit/src/services/state/mitre-techniques/mitre-techniques-concrete.service.ts
@@ -15,12 +15,19 @@ export class MitreTechniquesConcreteService extends MitreTechniquesService {
         super();
     }
 
+    private deferredErrors = [];
+
     getAll(): Observable<MitreTechnique[]> {
         return this.api.getMitreTechniquesList().pipe(
             tap(
                 (res) => this.mitreTechniquesSubject$.next(res),
-                (err) => this.errorHandler.emit(err, 'Loading MITRE techniques list'),
+                (err) => this.deferredErrors.push(err),
             ),
         );
+    }
+
+    emitDeferredErrors(): void {
+        this.deferredErrors.forEach((err) => this.errorHandler.emit(err, 'Loading MITRE techniques list'));
+        this.deferredErrors = [];
     }
 }

--- a/projects/training-agenda/definition-edit/src/services/state/mitre-techniques/mitre-techniques.service.ts
+++ b/projects/training-agenda/definition-edit/src/services/state/mitre-techniques/mitre-techniques.service.ts
@@ -11,4 +11,6 @@ export abstract class MitreTechniquesService {
     mitreTechniques$ = this.mitreTechniquesSubject$.asObservable();
 
     abstract getAll(): Observable<any>;
+
+    abstract emitDeferredErrors(): void;
 }

--- a/projects/training-agenda/package.json
+++ b/projects/training-agenda/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crczp/training-agenda",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "MIT",
     "peerDependencies": {
         "@angular/common": "^18.2.13",


### PR DESCRIPTION
Postpones mitre errors until relevant

For example, if mitre is unavailable, error will be thrown only if user clicks the form to assign a mitre technique to the outcomes

resolves #48 